### PR TITLE
Allow pathauto tokens to come from datastreams.

### DIFF
--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -258,6 +258,7 @@ class IslandoraFedoraObjectReadOnly implements ArrayAccess {
    * IslandoraFedoraObjectReadOnly constructor.
    *
    * @param FedoraObject $original
+   *   The FedoraObject for which this class is a wrapper.
    */
   public function __construct($original) {
     $this->fake = $original;
@@ -267,21 +268,25 @@ class IslandoraFedoraObjectReadOnly implements ArrayAccess {
   /**
    * Overload assignment to set label and nothing else.
    *
-   * @param $name
-   * @param $value
+   * @param string $name
+   *   The name of the property being set. Only a name of 'label' will have any effect.
+   * @param mixed $value
+   *   The value to which the property should be set.
    */
   public function __set($name, $value) {
     if ($name == 'label') {
       $this->savedLabel = $value;
     }
-    return;
   }
 
   /**
    * Overload get to pull values from original object (except for label).
    *
-   * @param $name
+   * @param string $name
+   *   The name of the property to get.
+   *
    * @return string|void
+   *   Returns the value of the property.
    */
   public function __get($name) {
     if ($name == 'label') {

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -79,7 +79,7 @@ function islandora_pathauto_pathauto($op) {
 /**
  * Wrapper to pathauto_create_alias().
  *
- * @param FedoraObject $object
+ * @param FedoraObject|IslandoraFedoraObjectReadOnly $object
  *   an Islandora object
  *
  * @param string $op
@@ -263,7 +263,7 @@ class IslandoraFedoraObjectReadOnly implements ArrayAccess {
     if ($name == 'label') {
       $this->_label = $value;
     }
-    return;  // DO NOTHING
+    return;  // Do nothing.
   }
 
   public function __get($name) {
@@ -282,10 +282,10 @@ class IslandoraFedoraObjectReadOnly implements ArrayAccess {
   }
 
   public function offsetSet($offset, $value) {
-    return;  // DO nothing
+    return;  // Do nothing.
   }
 
   public function offsetUnset($offset) {
-    return;  // DO nothing
+    return;  // Do nothing.
   }
 }

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -119,14 +119,12 @@ function islandora_pathauto_islandora_object_ingested($object) {
  * Implements hook_islandora_object_alter().
  */
 function islandora_pathauto_islandora_object_alter($original, $context) {
-  $object = (object) array(
-    'id' => $original->id,
-    'label' => $original->label,
-    'models' => $original->models,
-  );
 
-  // The object does not have the new label yet.
+  // If the label is what was modified, then
+  // the $original does not have the new label yet.
   // This is a nasty fix to get it from $context.
+  // See ISLANDORA-1072.
+  $object = new IslandoraFedoraObjectReadOnly($original);
   if (isset($context['action']) and $context['action'] == 'modify') {
     if (isset($context['params']['label'])) {
       $object->label = $context['params']['label'];
@@ -250,4 +248,44 @@ function islandora_pathauto_tokens($type, $tokens, array $data = array(), array 
     return $replacements;
   }
   return array();
+}
+
+class IslandoraFedoraObjectReadOnly implements ArrayAccess {
+  private $_fake;
+  private $_label;
+
+  public function __construct($original) {
+    $this->_fake = $original;
+    $this->_label = $original->label;
+  }
+
+  public function __set($name, $value) {
+    if ($name == 'label') {
+      $this->_label = $value;
+    }
+    return;  // DO NOTHING
+  }
+
+  public function __get($name) {
+    if ($name == 'label') {
+      return $this->_label;
+    }
+    return $this->_fake->__get($name);
+  }
+
+  public function offsetExists($offset) {
+    return isset($this->_fake[$offset]);
+  }
+
+  public function offsetGet($offset) {
+    return $this->_fake[$offset];
+  }
+
+  public function offsetSet($offset, $value) {
+    return;  // DO nothing
+  }
+
+  public function offsetUnset($offset) {
+    return;  // DO nothing
+  }
 }

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -269,7 +269,7 @@ class IslandoraFedoraObjectReadOnly implements ArrayAccess {
    * Overload assignment to set label and nothing else.
    *
    * @param string $name
-   *   The name of the property being set. Only a name of 'label' will have any effect.
+   *   The name of the property being set. Only 'label' will have any effect.
    * @param mixed $value
    *   The value to which the property should be set.
    */
@@ -312,14 +312,10 @@ class IslandoraFedoraObjectReadOnly implements ArrayAccess {
   /**
    * Implements ArrayAccess.
    */
-  public function offsetSet($offset, $value) {
-    return;
-  }
+  public function offsetSet($offset, $value) {}
 
   /**
    * Implements ArrayAccess.
    */
-  public function offsetUnset($offset) {
-    return;
-  }
+  public function offsetUnset($offset) {}
 }

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -251,41 +251,70 @@ function islandora_pathauto_tokens($type, $tokens, array $data = array(), array 
 }
 
 class IslandoraFedoraObjectReadOnly implements ArrayAccess {
-  private $_fake;
-  private $_label;
+  private $fake;
+  private $savedLabel;
 
+  /**
+   * IslandoraFedoraObjectReadOnly constructor.
+   *
+   * @param FedoraObject $original
+   */
   public function __construct($original) {
-    $this->_fake = $original;
-    $this->_label = $original->label;
+    $this->fake = $original;
+    $this->savedLabel = $original->label;
   }
 
+  /**
+   * Overload assignment to set label and nothing else.
+   *
+   * @param $name
+   * @param $value
+   */
   public function __set($name, $value) {
     if ($name == 'label') {
-      $this->_label = $value;
+      $this->savedLabel = $value;
     }
-    return;  // Do nothing.
+    return;
   }
 
+  /**
+   * Overload get to pull values from original object (except for label).
+   *
+   * @param $name
+   * @return string|void
+   */
   public function __get($name) {
     if ($name == 'label') {
-      return $this->_label;
+      return $this->savedLabel;
     }
-    return $this->_fake->__get($name);
+    return $this->fake->__get($name);
   }
 
+  /**
+   * Implements ArrayAccess.
+   */
   public function offsetExists($offset) {
-    return isset($this->_fake[$offset]);
+    return isset($this->fake[$offset]);
   }
 
+  /**
+   * Implements ArrayAccess.
+   */
   public function offsetGet($offset) {
-    return $this->_fake[$offset];
+    return $this->fake[$offset];
   }
 
+  /**
+   * Implements ArrayAccess.
+   */
   public function offsetSet($offset, $value) {
-    return;  // Do nothing.
+    return;
   }
 
+  /**
+   * Implements ArrayAccess.
+   */
   public function offsetUnset($offset) {
-    return;  // Do nothing.
+    return;
   }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1719
# What does this Pull Request do?

Exposes the whole Fedora object during hook_object_alter, so that other modules can make custom Fedora tokens (e.g. from the datastreams).

This is an improvement on a shitty workaround for https://jira.duraspace.org/browse/ISLANDORA-1073.
# What's new?

Previously, during hook_islandora_object_alter, we used a very minimal shell object that mimicked a Fedora object in that you could extract the label, PID, and content models. But to also be able to access datastreams, we needed a more thorough facade. 

This change defines a class, IslandoraFedoraObjectReadOnly, which lets you access the properties and datastreams of the underlying FedoraObject, but won't let you set properties of that FedoraObject. It also has an assignable label property. 

This whole workaround is only necessary because during hook_object_alter (and hook_islandora_object_modified) the $object we have to work with doesn't have the label that you may have just assigned to it. (ISLANDORA-1073).

The `implements ArrayAccess` bit allows us to test isset($object['MODS']) which otherwise would not make sense to PHP. 
# How should this be tested?

Test that existing functionality is maintained - a change to the label or other properties triggers an updated alias.

Bonus: Test that you can extend this by defining your own tokens with hook_token_info() and hook_tokens(), example module: https://github.com/roblib/islandora_pathauto_xpath
# Additional Notes:

Improved documentation in the Islandora Pathauto readme to come.
# Interested parties

@Islandora/7-x-1-x-committers
