### PR TITLE
for the pathauto bulkupdate option, added option to query using SOLR …

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -9,10 +9,11 @@
  * Admin form.
  */
 function islandora_pathauto_admin_settings(array $form, array &$form_state) {
-  // get possible query language types 
+  // Get possible query language types.
   $backend_options = module_invoke_all('islandora_basic_collection_query_backends');
-  // remove the legacy one since there would be no difference between legacy SPARQL and current SPARQL
-  unset( $backend_options[ISLANDORA_BASIC_COLLECTION_LEGACY_BACKEND] );
+  // Remove the legacy one since there would be no difference between legacy
+  // SPARQL and current SPARQL.
+  unset($backend_options[ISLANDORA_BASIC_COLLECTION_LEGACY_BACKEND]);
   $map_to_title = function ($backend) {
     return $backend['title'];
   };

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -44,14 +44,27 @@ function islandora_pathauto_admin_settings(array $form, array &$form_state) {
     '#tree' => TRUE,
     '#theme' => 'islandora_pathauto_admin_table',
   );
-  $form['query_language'] = array(
-    '#type' => 'radios',
-    '#title' => t('Query language'),
-    '#options' => array_map($map_to_title, $backend_options),
-    '#description' => t('Query language to use for finding the content models in the system for pathauto hooks.'),
-    '#default_value' => variable_get('islandora_pathauto_query_language', 'islandora_basic_collection_sparql_query_backend'),
-  );
-
+  // Only add this option if the module is installed.
+  if (module_exists('islandora_solr')) {
+    $form['solr_options_wrapper'] = array(
+      '#type' => 'fieldset',
+      '#title' => 'Query Islandora objects settings',
+      '#description' => 'Options related to Solr search module being installed',
+    );
+    $form['solr_options_wrapper']['query_language'] = array(
+      '#type' => 'radios',
+      '#title' => t('Query language'),
+      '#options' => array_map($map_to_title, $backend_options),
+      '#description' => t('Query language to use for finding the content models in the system for pathauto hooks.'),
+      '#default_value' => variable_get('islandora_pathauto_query_language', 'islandora_basic_collection_sparql_query_backend'),
+    );
+    $form['solr_options_wrapper']['query_limit'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Query limit'),
+      '#description' => t('The maximum number of objects to return for a Solr query.'),
+      '#default_value' => variable_get('islandora_pathauto_query_limit', '10000'),
+    );
+  }
   $alink_options = array(
     'attributes' => array('target' => '_blank'),
     'html' => TRUE,
@@ -95,7 +108,10 @@ function islandora_pathauto_admin_settings(array $form, array &$form_state) {
 function islandora_pathauto_admin_settings_submit($form, &$form_state) {
   $enabled = array_filter($form_state['values']['pathauto_table']['enabled']);
   variable_set('islandora_pathauto_selected_cmodels', array_keys($enabled));
-  variable_set('islandora_pathauto_query_language', $form_state['values']['query_language']);
+  if (module_exists('islandora_solr')) {
+    variable_set('islandora_pathauto_query_language', $form_state['values']['query_language']);
+    variable_set('islandora_pathauto_query_limit', $form_state['values']['query_limit']);
+  }
 }
 
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -9,6 +9,14 @@
  * Admin form.
  */
 function islandora_pathauto_admin_settings(array $form, array &$form_state) {
+  // get possible query language types 
+  $backend_options = module_invoke_all('islandora_basic_collection_query_backends');
+  // remove the legacy one since there would be no difference between legacy SPARQL and current SPARQL
+  unset( $backend_options[ISLANDORA_BASIC_COLLECTION_LEGACY_BACKEND] );
+  $map_to_title = function ($backend) {
+    return $backend['title'];
+  };
+
   module_load_include('inc', 'islandora', 'includes/utilities');
   drupal_add_css(drupal_get_path('module', 'islandora_image_annotation') . '/css/islandora_annotation.css');
   $all_cmodels = islandora_get_content_models();
@@ -35,6 +43,14 @@ function islandora_pathauto_admin_settings(array $form, array &$form_state) {
     '#tree' => TRUE,
     '#theme' => 'islandora_pathauto_admin_table',
   );
+  $form['query_language'] = array(
+    '#type' => 'radios',
+    '#title' => t('Query language'),
+    '#options' => array_map($map_to_title, $backend_options),
+    '#description' => t('Query language to use for finding the content models in the system for pathauto hooks.'),
+    '#default_value' => variable_get('islandora_pathauto_query_language', 'islandora_basic_collection_sparql_query_backend'),
+  );
+
   $alink_options = array(
     'attributes' => array('target' => '_blank'),
     'html' => TRUE,
@@ -78,6 +94,7 @@ function islandora_pathauto_admin_settings(array $form, array &$form_state) {
 function islandora_pathauto_admin_settings_submit($form, &$form_state) {
   $enabled = array_filter($form_state['values']['pathauto_table']['enabled']);
   variable_set('islandora_pathauto_selected_cmodels', array_keys($enabled));
+  variable_set('islandora_pathauto_query_language', $form_state['values']['query_language']);
 }
 
 

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -141,45 +141,102 @@ function islandora_pathauto_islandora_object_purged($pid) {
 }
 
 /**
+ * Gets the module results based on the type of query language specified by islandora_pathauto_query_language
+ *
+ *
+ * @return array 
+ *   results of object, title, cmodel 
+ */
+function islandora_pathauto_get_module_results() {
+  // step 1, get the enabled models
+  $models = variable_get('islandora_pathauto_selected_cmodels', array());
+  // depending on the query language, get the result records that match the enabled models 
+  $query_language = variable_get('islandora_pathauto_query_language', 'islandora_basic_collection_sparql_query_backend');
+  if ($query_language == 'islandora_basic_collection_sparql_query_backend') {
+    $first_contentmodel = array_shift($models);
+    $unions = '';
+    foreach ($models as $contentmodel) {
+      $unions .= 'UNION {
+              $object <fedora-model:label> $title ;
+              <fedora-model:hasModel> $cmodel ;
+              <fedora-model:state> <fedora-model:Active> .
+              FILTER(sameTerm($cmodel, <info:fedora/'.$contentmodel.'>))}
+              }';
+    }
+    $query = 'SELECT $object $title $cmodel
+          FROM <#ri>
+          WHERE { {
+              $object <fedora-model:label> $title ;
+              <fedora-model:hasModel> $cmodel ;
+              <fedora-model:state> <fedora-model:Active> .
+              FILTER(sameTerm($cmodel, <info:fedora/'.$first_contentmodel.'>))
+              }'.
+      $unions.'
+              ORDER BY $title';
+    $tuque = islandora_get_tuque_connection();
+    if ($tuque) {
+      try {
+        $results = $tuque->repository->ri->query($query, 'sparql');
+        return $results;
+      }
+      catch (Exception $e) {
+        return array();
+      }
+    } else {
+      IslandoraTuque::getError();
+    }
+  } elseif ((module_exists('islandora_solr') == true) && ($query_language == 'islandora_solr_query_backend')) {
+    module_load_include('inc', 'islandora_solr_search', 'includes/utilities');
+    $query_processor = new IslandoraSolrQueryProcessor();
+    $query_processor->solrQuery = 'RELS_EXT_hasModel_uri_s:(*'.str_replace(":", "\:", implode(" OR *", $models)).')';
+    $query_processor->solrStart = 0;
+    $query_processor->solrLimit = 1000;
+    $query_processor->solrParams = array(
+      // fl = $object $title $cmodel
+      'fl' => "PID,fgs_label_mt,RELS_EXT_hasModel_uri_s",
+      'fq' => "",
+    );
+    $url = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));
+    $solr = new Apache_Solr_Service($url['host'], $url['port'], $url['path'] . '/');
+    $solr->setCreateDocuments(FALSE);
+    try {
+      $results = $solr->search($query_processor->solrQuery, $query_processor->solrStart, $query_processor->solrLimit, $query_processor->solrParams, 'GET');
+      $tmp = json_decode($results->getRawResponse(), true);
+      $results = array();
+      foreach ($tmp['response']['docs'] as $trip) {
+        $results[]['object']['value'] = $trip['PID'];
+      }
+      return $results;
+    } catch (Exception $e) {
+      return array();
+    }
+  }
+}
+  
+/**
  * Implements hook_pathauto_bulkupdate().
  */
 function islandora_pathauto_pathauto_bulkupdate() {
   module_load_include('inc', 'islandora', 'includes/utilities');
-  $query = 'SELECT $object $title $cmodel
-        FROM <#ri>
-        WHERE {
-            $object <fedora-model:label> $title ;
-            <fedora-model:hasModel> $cmodel ;
-            <fedora-model:state> <fedora-model:Active> .
-            FILTER(!sameTerm($cmodel, <info:fedora/fedora-system:FedoraObject-3.0>))
-            }
-            ORDER BY $title';
-  $tuque = islandora_get_tuque_connection();
-  if ($tuque) {
-    try {
-      $results = $tuque->repository->ri->query($query, 'sparql');
-      $count = 0;
-      foreach ($results as $result) {
-        $pid = $result['object']['value'];
-        $object = islandora_object_load($pid);
-        $result = islandora_pathauto_create_alias($object, 'bulkupdate');
-        if ($result != '') {
-          $count += $result;
-        }
-      }
-      drupal_set_message($count . ' islandora aliases were updated.');
-    }
-    catch (Exception $e) {
-      if ($e->getCode() == '404') {
-        return FALSE;
-      }
-      else {
-        return NULL;
+  $results = islandora_pathauto_get_module_results();
+  try {
+    $count = 0;
+    foreach ($results as $result) {
+      $pid = $result['object']['value'];
+      $object = islandora_object_load($pid);
+      $result = islandora_pathauto_create_alias($object, 'bulkupdate');
+      if ($result != '') {
+        $count += $result;
       }
     }
-  }
-  else {
-    IslandoraTuque::getError();
+    drupal_set_message($count . ' islandora aliases were updated.');
+  } catch (Exception $e) {
+    if ($e->getCode() == '404') {
+      return FALSE;
+    }
+    else {
+      return NULL;
+    }
   }
   // Assuming access denied in all other cases for now.
   return NULL;

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -380,5 +380,3 @@ class IslandoraFedoraObjectReadOnly implements ArrayAccess {
    */
   public function offsetUnset($offset) {}
 }
-
-?>

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -195,7 +195,7 @@ function islandora_pathauto_get_module_results() {
     $query_processor = new IslandoraSolrQueryProcessor();
     $query_processor->solrQuery = 'RELS_EXT_hasModel_uri_s:(*' . str_replace(":", "\:", implode(" OR *", $models)) . ')';
     $query_processor->solrStart = 0;
-    $query_processor->solrLimit = 1000;
+    $query_processor->solrLimit = variable_get('islandora_pathauto_query_limit', '10000');
     $query_processor->solrParams = array(
       'fl' => "PID,fgs_label_mt,RELS_EXT_hasModel_uri_s",
       'fq' => "",

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -141,7 +141,9 @@ function islandora_pathauto_islandora_object_purged($pid) {
 }
 
 /**
- * Gets the module results based on the type of query language specified by
+ * Gets the islandora_pathauto module results. 
+ *
+ * This is based on the query language specified by
  * islandora_pathauto_query_language.
  *
  *
@@ -162,7 +164,7 @@ function islandora_pathauto_get_module_results() {
               $object <fedora-model:label> $title ;
               <fedora-model:hasModel> $cmodel ;
               <fedora-model:state> <fedora-model:Active> .
-              FILTER(sameTerm($cmodel, <info:fedora/'. $contentmodel .'>))}
+              FILTER(sameTerm($cmodel, <info:fedora/' . $contentmodel . '>))}
               }';
     }
     $query = 'SELECT $object $title $cmodel
@@ -171,8 +173,8 @@ function islandora_pathauto_get_module_results() {
               $object <fedora-model:label> $title ;
               <fedora-model:hasModel> $cmodel ;
               <fedora-model:state> <fedora-model:Active> .
-              FILTER(sameTerm($cmodel, <info:fedora/'. $first_contentmodel .'>))
-              }'. $unions .'
+              FILTER(sameTerm($cmodel, <info:fedora/' . $first_contentmodel . '>))
+              }' . $unions . '
               ORDER BY $title';
     $tuque = islandora_get_tuque_connection();
     if ($tuque) {
@@ -191,7 +193,7 @@ function islandora_pathauto_get_module_results() {
   elseif ((module_exists('islandora_solr') == TRUE) && ($query_language == 'islandora_solr_query_backend')) {
     module_load_include('inc', 'islandora_solr_search', 'includes/utilities');
     $query_processor = new IslandoraSolrQueryProcessor();
-    $query_processor->solrQuery = 'RELS_EXT_hasModel_uri_s:(*'. str_replace(":", "\:", implode(" OR *", $models)) .')';
+    $query_processor->solrQuery = 'RELS_EXT_hasModel_uri_s:(*' . str_replace(":", "\:", implode(" OR *", $models)) . ')';
     $query_processor->solrStart = 0;
     $query_processor->solrLimit = 1000;
     $query_processor->solrParams = array(

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -141,16 +141,18 @@ function islandora_pathauto_islandora_object_purged($pid) {
 }
 
 /**
- * Gets the module results based on the type of query language specified by islandora_pathauto_query_language
+ * Gets the module results based on the type of query language specified by
+ * islandora_pathauto_query_language.
  *
  *
- * @return array 
- *   results of object, title, cmodel 
+ * @return array
+ *   results of object, title, cmodel
  */
 function islandora_pathauto_get_module_results() {
-  // step 1, get the enabled models
+  // Step 1, get the enabled models.
   $models = variable_get('islandora_pathauto_selected_cmodels', array());
-  // depending on the query language, get the result records that match the enabled models 
+  // Depending on the query language, get the result records that match the
+  // enabled models.
   $query_language = variable_get('islandora_pathauto_query_language', 'islandora_basic_collection_sparql_query_backend');
   if ($query_language == 'islandora_basic_collection_sparql_query_backend') {
     $first_contentmodel = array_shift($models);
@@ -160,7 +162,7 @@ function islandora_pathauto_get_module_results() {
               $object <fedora-model:label> $title ;
               <fedora-model:hasModel> $cmodel ;
               <fedora-model:state> <fedora-model:Active> .
-              FILTER(sameTerm($cmodel, <info:fedora/'.$contentmodel.'>))}
+              FILTER(sameTerm($cmodel, <info:fedora/'. $contentmodel .'>))}
               }';
     }
     $query = 'SELECT $object $title $cmodel
@@ -169,9 +171,8 @@ function islandora_pathauto_get_module_results() {
               $object <fedora-model:label> $title ;
               <fedora-model:hasModel> $cmodel ;
               <fedora-model:state> <fedora-model:Active> .
-              FILTER(sameTerm($cmodel, <info:fedora/'.$first_contentmodel.'>))
-              }'.
-      $unions.'
+              FILTER(sameTerm($cmodel, <info:fedora/'. $first_contentmodel .'>))
+              }'. $unions .'
               ORDER BY $title';
     $tuque = islandora_get_tuque_connection();
     if ($tuque) {
@@ -182,17 +183,18 @@ function islandora_pathauto_get_module_results() {
       catch (Exception $e) {
         return array();
       }
-    } else {
+    }
+    else {
       IslandoraTuque::getError();
     }
-  } elseif ((module_exists('islandora_solr') == true) && ($query_language == 'islandora_solr_query_backend')) {
+  }
+  elseif ((module_exists('islandora_solr') == TRUE) && ($query_language == 'islandora_solr_query_backend')) {
     module_load_include('inc', 'islandora_solr_search', 'includes/utilities');
     $query_processor = new IslandoraSolrQueryProcessor();
-    $query_processor->solrQuery = 'RELS_EXT_hasModel_uri_s:(*'.str_replace(":", "\:", implode(" OR *", $models)).')';
+    $query_processor->solrQuery = 'RELS_EXT_hasModel_uri_s:(*'. str_replace(":", "\:", implode(" OR *", $models)) .')';
     $query_processor->solrStart = 0;
     $query_processor->solrLimit = 1000;
     $query_processor->solrParams = array(
-      // fl = $object $title $cmodel
       'fl' => "PID,fgs_label_mt,RELS_EXT_hasModel_uri_s",
       'fq' => "",
     );
@@ -201,18 +203,19 @@ function islandora_pathauto_get_module_results() {
     $solr->setCreateDocuments(FALSE);
     try {
       $results = $solr->search($query_processor->solrQuery, $query_processor->solrStart, $query_processor->solrLimit, $query_processor->solrParams, 'GET');
-      $tmp = json_decode($results->getRawResponse(), true);
+      $tmp = json_decode($results->getRawResponse(), TRUE);
       $results = array();
       foreach ($tmp['response']['docs'] as $trip) {
         $results[]['object']['value'] = $trip['PID'];
       }
       return $results;
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       return array();
     }
   }
 }
-  
+
 /**
  * Implements hook_pathauto_bulkupdate().
  */
@@ -230,7 +233,8 @@ function islandora_pathauto_pathauto_bulkupdate() {
       }
     }
     drupal_set_message($count . ' islandora aliases were updated.');
-  } catch (Exception $e) {
+  }
+  catch (Exception $e) {
     if ($e->getCode() == '404') {
       return FALSE;
     }
@@ -376,3 +380,5 @@ class IslandoraFedoraObjectReadOnly implements ArrayAccess {
    */
   public function offsetUnset($offset) {}
 }
+
+?>


### PR DESCRIPTION
**JIRA Ticket**: (link)
does not apply 
- Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
  This is not related to anything external.
# What does this Pull Request do?

Add an option to use SOLR query to find the models associated with the bulk update feature of pathauto via islandora_pathauto.  If not configured at all, there should be no difference when executing a pathauto bulk update.

For our installation, SPARQL performance is an issue.  We want to add the configuration choice to use SOLR for the pathauto bulk update query.  This SOLR option as well as the query will only run if the islandora_solr_search module is installed.
# What's new?

A in-depth description of the changes made by this PR. Technical details and possible side effects.
Added a radio selection between SPARQL and SOLR for the "Query Language" in the islandora_pathauto configuration.  This relates to a new variable "islandora_pathauto_query_language" and is used in creating the query in a new function "islandora_pathauto_get_module_results" that is which is called from islandora_pathauto_pathauto_bulkupdate to replace the code that was only getting SPARQL query results.
# How should this be tested?

There is no real way to do a dry-run (without affecting data and URL aliases), but you may be able to confirm that the number of newly generated pathauto aliases match up with the expected number of models when you run it.
# Additional Notes:

This change will only make a difference to the islandora_pathauto module when the islandora_solr_search module is also installed... otherwise, you will never notice any change.
