### PR TITLE
ISLANDORA-1768 Pathauto bulk update respects namespaces.

### DIFF
--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -161,10 +161,12 @@ function islandora_pathauto_pathauto_bulkupdate() {
       $count = 0;
       foreach ($results as $result) {
         $pid = $result['object']['value'];
-        $object = islandora_object_load($pid);
-        $result = islandora_pathauto_create_alias($object, 'bulkupdate');
-        if ($result != '') {
-          $count += $result;
+        if (islandora_namespace_accessible($pid)) {
+          $object = islandora_object_load($pid);
+          $result = islandora_pathauto_create_alias($object, 'bulkupdate');
+          if ($result != '') {
+            $count += $result;
+          }
         }
       }
       drupal_set_message($count . ' islandora aliases were updated.');


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1728

7.x Branch PR: #20 
# What does this Pull Request do?

Prevents Pathauto's bulk upload from creating many useless aliases for objects in the repository but inaccessible from the Islandora site.
# What's new?

Checks if objects are in an accessible namespace before creating each alias during batch creation.
# How should this be tested?

Create objects in multiple namespaces and limit your site to exclude some; then create patterns for Islandora objects (admin/config/search/path/patterns) and apply them using Pathauto's Bulk Update (admin/config/search/path/update_bulk). 
Before: you get aliases for the inaccessible objects.
After: you only get aliases for the accessible ones.
# Additional Notes:

No documentation, dependencies, or impact on existing code. 
Related (as in, uses the same fix) as https://github.com/Islandora/islandora_solution_pack_entities/pull/105 
# Interested parties

@Islandora/7-x-1-x-committers because this issue was my own module shooting myself in the foot. Testers/mergers would be appreciated. 
