### PR TITLE
7.x islandora 1728

### DIFF
--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -99,6 +99,7 @@ function islandora_pathauto_create_alias($object, $op) {
   if (!$models) {
     $models = $object->models;
   }
+  dd($models, 'models');
   foreach ($models as $cmodel) {
     $result = pathauto_create_alias('islandora', $op, $path, array('fedora' => $object), $cmodel);
     if ($result != '') {
@@ -143,48 +144,93 @@ function islandora_pathauto_islandora_object_purged($pid) {
 /**
  * Implements hook_pathauto_bulkupdate().
  */
-function islandora_pathauto_pathauto_bulkupdate() {
+function islandora_pathauto_pathauto_bulkupdate(&$context) {
   module_load_include('inc', 'islandora', 'includes/utilities');
-  $query = 'SELECT $object $title $cmodel
-        FROM <#ri>
-        WHERE {
-            $object <fedora-model:label> $title ;
-            <fedora-model:hasModel> $cmodel ;
-            <fedora-model:state> <fedora-model:Active> .
-            FILTER(!sameTerm($cmodel, <info:fedora/fedora-system:FedoraObject-3.0>))
-            }
-            ORDER BY $title';
+  $sandbox = &$context['sandbox'];
+  if (empty($sandbox)) {
+    $sandbox['bob'] = 0;
+    $sandbox['total'] = 0;
+    $sandbox['total_alias'] = 0;
+    $sandbox['total_processed'] = 0;
+
+    $sandbox['models'] = variable_get('islandora_pathauto_selected_cmodels', array());
+    if (empty($sandbox['models'])) {
+      drupal_set_message(t('No Islandora content models selected'), 'warning');
+      $context['finished'] = 1;
+        return;
+    }
+    $sandbox['filters'] = array();
+    $model_filters = $sandbox['models'];
+    foreach ($model_filters as &$filter) {
+      $filter = "sameTerm(?model, <info:fedora/$filter>)";
+    }
+    $sandbox['filters']['model'] = format_string('FILTER(!models)', array('!models' => implode(' || ', $model_filters)));
+  }
+
+  $sandbox['bob']++;
+
+  $query = <<<EOQ
+SELECT ?object ?cd ?title
+FROM <#ri>
+WHERE {
+  ?object <fedora-model:label> ?title ;
+  <info:fedora/fedora-system:def/model#createdDate> ?cd ;
+  <fedora-model:hasModel> ?model ;
+  <fedora-model:state> <fedora-model:Active> .
+  !filters
+}
+ORDER BY ?cd
+!limit
+EOQ;
+
   $tuque = islandora_get_tuque_connection();
   if ($tuque) {
-    try {
-      $results = $tuque->repository->ri->query($query, 'sparql');
-      $count = 0;
-      foreach ($results as $result) {
+    $context['finished'] = 0;
+    if ($sandbox['total'] == 0) {
+      $query_string = format_string($query, array('!filters' => implode(' ', $sandbox['filters']), '!limit' => ''));
+      $sandbox['total'] = $tuque->repository->ri->countQuery($query_string, 'sparql');
+      if ($sandbox['total'] == 0) {
+        $context['finished'] = 1;
+        drupal_set_message(t('No objects found for selected modules (@models).', array('@models' => implode(', ', $sandbox['models']))));
+        return t('No objects found.');
+      }
+    }
+    if (isset($sandbox['cd'])) {
+      $sandbox['filters']['cd'] = "FILTER(?cd > '{$sandbox['cd']}'^^xsd:dateTime)";
+    }
+    else {
+      $sandbox['filters']['cd'] = '';
+    }
+
+    $limit = 1;
+    $query_string = format_string($query, array('!filters' => implode(' ', $sandbox['filters']), '!limit' => "LIMIT $limit"));
+    $results = $tuque->repository->ri->sparqlQuery($query_string);
+    if (empty($results)) {
+      $context['finished'] = 1;
+    }
+    else {
+      $sandbox['total_processed'] += count($results);
+      foreach($results as $result) {
         $pid = $result['object']['value'];
+        $sandbox['cd'] = $result['cd']['value'];
         $object = islandora_object_load($pid);
-        $result = islandora_pathauto_create_alias($object, 'bulkupdate');
-        if ($result != '') {
-          $count += $result;
+        if ($object) {
+          $alias = islandora_pathauto_create_alias($object, 'bulkupdate');
+          if ($alias != "") {
+            $sandbox['total_alias']++;
+          }
+        }
+        else {
+          //log error.. or add to context fail list?
         }
       }
-      drupal_set_message($count . ' islandora aliases were updated.');
-    }
-    catch (Exception $e) {
-      if ($e->getCode() == '404') {
-        return FALSE;
-      }
-      else {
-        return NULL;
-      }
     }
   }
-  else {
-    IslandoraTuque::getError();
+  $context['message'] = t('Processed @total_processed of @total. Added @total_alias aliases.', array('@total_processed' => $sandbox['total_processed'], '@total_alias' => $sandbox['total_alias'], '@total' => $sandbox['total']));
+  if ($context['finished'] == 1) {
+    drupal_set_message(t('Added @total_alias aliases on @total_processed PIDs.', array('@total_alias' => $sandbox['total_alias'], '@total_processed' => $sandbox['total_processed'])));
   }
-  // Assuming access denied in all other cases for now.
-  return NULL;
 }
-
 
 /**
  * Implements hook_path_alias_types().

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -97,21 +97,24 @@ function islandora_pathauto_pathauto($op) {
  */
 function islandora_pathauto_create_alias($object, $op) {
   module_load_include('inc', 'pathauto');
-  $path = 'islandora/object/' . $object->id;
   $count = 0;
-  // Give priority to any cmodels that are enabled for pathauto.
-  $all_enabled = variable_get('islandora_pathauto_selected_cmodels', array());
-  $models = array_intersect($object->models, $all_enabled);
-  if (!$models) {
-    $models = $object->models;
-  }
+  if (islandora_namespace_accessible($object->id)) {
+    $path = 'islandora/object/' . $object->id;
+    // Give priority to any cmodels that are enabled for pathauto.
+    $all_enabled = variable_get('islandora_pathauto_selected_cmodels', array());
+    $models = array_intersect($object->models, $all_enabled);
+    if (!$models) {
+      $models = $object->models;
+    }
 
-  foreach ($models as $cmodel) {
-    $result = pathauto_create_alias('islandora', $op, $path, array('fedora' => $object), $cmodel);
-    if ($result != '') {
-      $count++;
+    foreach ($models as $cmodel) {
+      $result = pathauto_create_alias('islandora', $op, $path, array('fedora' => $object), $cmodel);
+      if ($result != '') {
+        $count++;
+      }
     }
   }
+
   return $count;
 }
 
@@ -187,6 +190,14 @@ function islandora_pathauto_pathauto_bulkupdate(&$context) {
       $filter = "sameTerm(?model, <info:fedora/$filter>)";
     }
     $sandbox['filters']['model'] = format_string('FILTER(!models)', array('!models' => implode(' || ', $model_filters)));
+
+    if (variable_get('islandora_namespace_restriction_enforced', FALSE)) {
+      $allowed_namespaces = islandora_get_allowed_namespaces();
+      foreach ($allowed_namespaces as &$ns) {
+        $ns = "regex(str(?object), \"^info:fedora/$ns\")";
+      }
+      $sandbox['filters']['ns'] = format_string('FILTER(!ns)', array('!ns' => implode(' || ', $allowed_namespaces)));
+    }
   }
 
   $query = <<<EOQ

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -53,27 +53,33 @@ function islandora_pathauto_theme() {
  * Implements hook_pathauto().
  */
 function islandora_pathauto_pathauto($op) {
-  module_load_include('inc', 'islandora', 'includes/utilities');
-  $settings = new stdClass();
-  $settings->module = 'islandora';
-  $settings->groupheader = t('Islandora object paths');
-  $settings->patterndescr = t('All Islandora objects (except those with custom paths specified below)');
-  $settings->patterndefault = '';
-  $settings->token_type = 'fedora';
-  $settings->patternitems = array();
-  $settings->batch_update_callback = 'islandora_pathauto_pathauto_bulkupdate';
-  $all_cmodels = islandora_get_content_models();
-  $pathauto_cmodels = variable_get('islandora_pathauto_selected_cmodels', array());
-  $cmodels = array();
-  foreach ($all_cmodels as $key => $value) {
-    if (in_array($key, $pathauto_cmodels)) {
-      $cmodels[$key] = $value;
-    }
+  switch ($op) {
+    case 'settings':
+      module_load_include('inc', 'islandora', 'includes/utilities');
+      $settings = new stdClass();
+      $settings->module = 'islandora';
+      $settings->groupheader = t('Islandora object paths');
+      $settings->patterndescr = t('All Islandora objects (except those with custom paths specified below)');
+      $settings->patterndefault = '';
+      $settings->token_type = 'fedora';
+      $settings->patternitems = array();
+      $settings->batch_update_callback = 'islandora_pathauto_pathauto_bulkupdate';
+      $all_cmodels = islandora_get_content_models();
+      $pathauto_cmodels = variable_get('islandora_pathauto_selected_cmodels', array());
+      $cmodels = array();
+      foreach ($all_cmodels as $key => $value) {
+        if (in_array($key, $pathauto_cmodels)) {
+          $cmodels[$key] = $value;
+        }
+      }
+      foreach ($cmodels as $cmodel) {
+        $settings->patternitems[$cmodel['pid']] = t('Custom pattern for @cmodel objects', array("@cmodel" => $cmodel['label']));
+      }
+      return $settings;
+
+    default:
+      break;
   }
-  foreach ($cmodels as $cmodel) {
-    $settings->patternitems[$cmodel['pid']] = t('Custom pattern for @cmodel objects', array("@cmodel" => $cmodel['label']));
-  }
-  return $settings;
 }
 
 /**
@@ -99,7 +105,7 @@ function islandora_pathauto_create_alias($object, $op) {
   if (!$models) {
     $models = $object->models;
   }
-  dd($models, 'models');
+
   foreach ($models as $cmodel) {
     $result = pathauto_create_alias('islandora', $op, $path, array('fedora' => $object), $cmodel);
     if ($result != '') {
@@ -148,26 +154,40 @@ function islandora_pathauto_pathauto_bulkupdate(&$context) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   $sandbox = &$context['sandbox'];
   if (empty($sandbox)) {
-    $sandbox['bob'] = 0;
     $sandbox['total'] = 0;
     $sandbox['total_alias'] = 0;
     $sandbox['total_processed'] = 0;
-
-    $sandbox['models'] = variable_get('islandora_pathauto_selected_cmodels', array());
-    if (empty($sandbox['models'])) {
-      drupal_set_message(t('No Islandora content models selected'), 'warning');
-      $context['finished'] = 1;
-        return;
-    }
     $sandbox['filters'] = array();
+    $sandbox['filters']['model'] = '';
+    $sandbox['models'] = array();
+    $settings = islandora_pathauto_pathauto('settings');
+    $pattern_all_objects = variable_get('pathauto_' . $settings->module . '_pattern', $settings->patterndefault);
+    // Determine what content models have a pattern and
+    // only query objects with those particular models.
+    if (!empty($pattern_all_objects)) {
+      $sandbox['models'][] = 'fedora-system:FedoraObject-3.0';
+    }
+    elseif (isset($settings->patternitems)) {
+      foreach ($settings->patternitems as $model => $label) {
+        $pattern = variable_get('pathauto_' . $settings->module . '_' . $model . '_pattern', '');
+        if (!empty($pattern)) {
+          $sandbox['models'][] = $model;
+        }
+      }
+    }
+
+    if (empty($sandbox['models'])) {
+      drupal_set_message(t('No patterns exist for Islandora objects.'), 'warning');
+      $context['finished'] = 1;
+      return;
+    }
+
     $model_filters = $sandbox['models'];
     foreach ($model_filters as &$filter) {
       $filter = "sameTerm(?model, <info:fedora/$filter>)";
     }
     $sandbox['filters']['model'] = format_string('FILTER(!models)', array('!models' => implode(' || ', $model_filters)));
   }
-
-  $sandbox['bob']++;
 
   $query = <<<EOQ
 SELECT ?object ?cd ?title
@@ -187,7 +207,9 @@ EOQ;
   if ($tuque) {
     $context['finished'] = 0;
     if ($sandbox['total'] == 0) {
-      $query_string = format_string($query, array('!filters' => implode(' ', $sandbox['filters']), '!limit' => ''));
+      $query_string = format_string($query, array(
+        '!filters' => implode(' ', $sandbox['filters']),
+        '!limit' => ''));
       $sandbox['total'] = $tuque->repository->ri->countQuery($query_string, 'sparql');
       if ($sandbox['total'] == 0) {
         $context['finished'] = 1;
@@ -202,15 +224,17 @@ EOQ;
       $sandbox['filters']['cd'] = '';
     }
 
-    $limit = 1;
-    $query_string = format_string($query, array('!filters' => implode(' ', $sandbox['filters']), '!limit' => "LIMIT $limit"));
+    $limit = 50;
+    $query_string = format_string($query, array(
+      '!filters' => implode(' ', $sandbox['filters']),
+      '!limit' => "LIMIT $limit"));
     $results = $tuque->repository->ri->sparqlQuery($query_string);
     if (empty($results)) {
       $context['finished'] = 1;
     }
     else {
       $sandbox['total_processed'] += count($results);
-      foreach($results as $result) {
+      foreach ($results as $result) {
         $pid = $result['object']['value'];
         $sandbox['cd'] = $result['cd']['value'];
         $object = islandora_object_load($pid);
@@ -220,13 +244,13 @@ EOQ;
             $sandbox['total_alias']++;
           }
         }
-        else {
-          //log error.. or add to context fail list?
-        }
       }
     }
   }
-  $context['message'] = t('Processed @total_processed of @total. Added @total_alias aliases.', array('@total_processed' => $sandbox['total_processed'], '@total_alias' => $sandbox['total_alias'], '@total' => $sandbox['total']));
+  $context['message'] = t('Processed @total_processed of @total. Added @total_alias aliases.', array(
+    '@total_processed' => $sandbox['total_processed'],
+    '@total_alias' => $sandbox['total_alias'],
+    '@total' => $sandbox['total']));
   if ($context['finished'] == 1) {
     drupal_set_message(t('Added @total_alias aliases on @total_processed PIDs.', array('@total_alias' => $sandbox['total_alias'], '@total_processed' => $sandbox['total_processed'])));
   }

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -191,11 +191,9 @@ function islandora_pathauto_pathauto_bulkupdate(&$context) {
     }
     $sandbox['filters']['model'] = format_string('FILTER(!models)', array('!models' => implode(' || ', $model_filters)));
     if (variable_get('islandora_namespace_restriction_enforced', FALSE)) {
-      $allowed_namespaces = islandora_get_allowed_namespaces();
-      foreach ($allowed_namespaces as &$ns) {
-        $ns = "regex(str(?object), \"^info:fedora/$ns\")";
-      }
-      $sandbox['filters']['ns'] = format_string('FILTER(!ns)', array('!ns' => implode(' || ', $allowed_namespaces)));
+      $namespace_array = islandora_get_allowed_namespaces();
+      $namespace_sparql = implode('|', $namespace_array);
+      $sandbox['filters']['ns'] = format_string('FILTER(regex(str(?object), "info:fedora/(!namespaces):"))', array('!namespaces' => $namespace_sparql));
     }
   }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1728

# What does this Pull Request do?
Prevents Pathauto from creating many useless aliases for objects in the repository but inaccessible from the Islandora site.

# What's new?
Checks if objects are in an accessible namespace before querying and creating each alias.

# How should this be tested?
Create objects in multiple namespaces and limit your site to exclude some; then create patterns for Islandora objects (admin/config/search/path/patterns) and apply them using Pathauto's Bulk Update (admin/config/search/path/update_bulk).
Before: you get aliases for the inaccessible objects.
After: you only get aliases for the accessible ones.


# Additional Notes:
* Does this change require documentation to be updated?  No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties
@rosiel 
