### PR TITLE
Remove unused CSS from another module.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -10,7 +10,6 @@
  */
 function islandora_pathauto_admin_settings(array $form, array &$form_state) {
   module_load_include('inc', 'islandora', 'includes/utilities');
-  drupal_add_css(drupal_get_path('module', 'islandora_image_annotation') . '/css/islandora_annotation.css');
   $all_cmodels = islandora_get_content_models();
   $already_chosen = variable_get('islandora_pathauto_selected_cmodels', array());
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1938

# What does this Pull Request do?
Remove the attempted included CSS from an external module.

# What's new?
No warnings of a module not existing when accessing the admin form at admin/islandora/tools/islandora-pathauto

# How should this be tested?
Navigate to /admin/islandora/tools/islandora-pathauto without the islandora_image_annotation moduel present. Note the warning present, pull the code note the warning go away.

# Interested parties
@rosiel
