### PR TITLE
ISLANDORA-1958 Remove duplicate alias on ingest.

### DIFF
--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -129,7 +129,10 @@ function islandora_pathauto_islandora_object_ingested($object) {
  * Implements hook_islandora_object_alter().
  */
 function islandora_pathauto_islandora_object_alter($original, $context) {
-
+  // Skip for new objects. hook_islandora_object_ingested will create the alias.
+  if (isset($context['action']) and $context['action'] == 'ingest') {
+    return;
+  }
   // If the label is what was modified, then
   // the $original does not have the new label yet.
   // This is a nasty fix to get it from $context.


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1958
Sister (release) PR to #32 

# What does this Pull Request do?

Stop generating two aliases on ingest.

# What's new?

Changes the alter hook implementation so that when hook_alter is called during object ingest, no alias is generated (it will be called during hook_ingest).

# How should this be tested?

Kim Pham's instructions from the Jira ticket:

> Steps to reproduce
> 1. Pathauto set custom pattern: anything/[fedora:pid]
> 2. Ingest an islandora object
> What is expected to happen:
> alias URL is automatically generated, produces one alias
> What actually happens:
> Upon ingest, path autogenerates 2 duplicate url aliases (see attached screenshot)

# Additional Notes:
I don't remember this being an issue 3 years ago, but I can't tell what code changed that caused this to start happening. 

# Interested parties
@kimpham54 (reporter) @nhart (maintainer)
