### PR TITLE
Add option to query objects using Solr

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ formats. To enable custom paths for specific content models, first enable the de
 
 Aliases can include the object's pid (`[fedora:pid]`), the Fedora label (`[fedora:label]`), the namespace (`[fedora:namespace]`), and/or the pid without the namespace (`[fedora:shortpid]`). See the documentation for [Pathauto](https://www.drupal.org/documentation/modules/pathauto) for more information on creating aliases, and read the FAQ below.
 
+When creating aliases in batch, Islandora Pathauto will default to using a Sparql query to the Triple Store. This can be changed to using Solr, with the added advantage that it is possible to specify the base Solr query, which can be useful in case of multisites.
+
 ## Documentation
 
 Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Islandora+Pathauto).

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -59,6 +59,29 @@ function islandora_pathauto_admin_settings(array $form, array &$form_state) {
     '#default_value' => $already_chosen,
   );
 
+  $options = array('sparql' => t('Sparql'));
+  if (module_exists('islandora_solr')) {
+    $options['solr'] = t('Solr');
+  }
+  $form['objects_query'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Objects Query Method'),
+  );
+  $form['objects_query']['objects_query_method'] = array(
+    '#type' => 'radios',
+    '#options' => $options,
+    '#default_value' => variable_get('islandora_pathauto_objects_query_method', 'sparql'),
+  );
+  $form['objects_query']['objects_query_solr'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr query'),
+    '#description' => t('The Solr query to use to find all objects. In most cases *:* is good, but for multisites you may want to filter by ancestors_ms:"root_collection_id".'),
+    '#states' => array(
+      'visible' => array('input[name=objects_query_method]' => array('value' => 'solr')),
+    ),
+    '#default_value' => variable_get('islandora_pathauto_objects_query_solr', '*:*'),
+  );
+
   $form['use_cron'] = array(
     '#type' => 'checkbox',
     '#title' => t('Use cron to automatically add / update aliases.'),
@@ -84,6 +107,8 @@ function islandora_pathauto_admin_settings_submit($form, &$form_state) {
   $enabled = array_filter($form_state['values']['pathauto_table']['enabled']);
   variable_set('islandora_pathauto_selected_cmodels', array_keys($enabled));
   variable_set('islandora_pathauto_use_cron', $form_state['values']['use_cron']);
+  variable_set('islandora_pathauto_objects_query_method', $form_state['values']['objects_query_method']);
+  variable_set('islandora_pathauto_objects_query_solr', $form_state['values']['objects_query_solr']);
 }
 
 /**

--- a/islandora_pathauto.install
+++ b/islandora_pathauto.install
@@ -14,6 +14,8 @@ function islandora_pathauto_uninstall() {
   $variables = array(
     'islandora_pathauto_use_cron',
     'islandora_pathauto_selected_cmodels',
+    'islandora_pathauto_objects_query_method',
+    'islandora_pathauto_objects_query_solr',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -162,14 +162,32 @@ function islandora_pathauto_islandora_object_purged($pid) {
  *   Batch context.
  */
 function islandora_pathauto_bulk_batch_process($use_cron_last = FALSE, &$context = array()) {
+  $fromdate = NULL;
+  if ($use_cron_last) {
+    $fromdate = gmdate("Y-m-d\TH:i:s\Z", variable_get('cron_last'));
+  }
+  islandora_pathauto_bulk_batch_process_from_date($fromdate, $context);
+
+  $sandbox = $context['sandbox'];
+  if (isset($sandbox['warning'])) {
+    drupal_set_message($sandbox['warning'], 'warning');
+  }
+  if ($context['finished'] == 1) {
+    drupal_set_message(t('Added @total_alias aliases on @total_processed PIDs.', array('@total_alias' => $sandbox['total_alias'], '@total_processed' => $sandbox['total_processed'])));
+  }
+}
+
+/**
+ * Batch operation for generating aliases for Islandora objects.
+ *
+ * @param string $fromdate
+ *   Process only objects that have a modification date greater than this date.
+ * @param array $context
+ *   Batch context.
+ */
+function islandora_pathauto_bulk_batch_process_from_date($fromdate = NULL, &$context = array()) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   $sandbox = &$context['sandbox'];
-  $args = array(
-    '!filters' => '',
-    '!limit' => '',
-    '!md_name' => '',
-    '!md_field' => '',
-  );
   if (empty($sandbox)) {
     $sandbox['total'] = 0;
     $sandbox['total_alias'] = 0;
@@ -194,11 +212,44 @@ function islandora_pathauto_bulk_batch_process($use_cron_last = FALSE, &$context
     }
 
     if (empty($sandbox['models'])) {
-      drupal_set_message(t('No patterns exist for Islandora objects.'), 'warning');
+      $sandbox['warning'] = t('No patterns exist for Islandora objects.');
       $context['finished'] = 1;
       return;
     }
+  }
 
+  if (variable_get('islandora_pathauto_objects_query_method', 'sparql') === 'solr') {
+    islandora_pathauto_bulk_batch_process_from_date_solr($fromdate, $context);
+  }
+  else {
+    islandora_pathauto_bulk_batch_process_from_date_sparql($fromdate, $context);
+  }
+
+  $context['message'] = t('Processed @total_processed of @total. Added @total_alias aliases.', array(
+    '@total_processed' => $sandbox['total_processed'],
+    '@total_alias' => $sandbox['total_alias'],
+    '@total' => $sandbox['total']));
+}
+
+/**
+ * Batch operation for generating aliases for Islandora objects via Sparql.
+ *
+ * @param string $fromdate
+ *   Process only objects that have a modification date greater than this date,
+ *   formatted as YYYY-MM-DD'T'hh:mm:ss'Z', e.g. 2020-05-14T23:59:59Z.
+ * @param array $context
+ *   Batch context.
+ */
+function islandora_pathauto_bulk_batch_process_from_date_sparql($fromdate = NULL, &$context = array()) {
+  $batchsize = 50;
+  $sandbox = &$context['sandbox'];
+  $args = array(
+    '!filters' => '',
+    '!limit' => '',
+    '!md_name' => '',
+    '!md_field' => '',
+  );
+  if (empty($sandbox) || $sandbox['total_processed'] === 0) {
     $model_filters = $sandbox['models'];
     foreach ($model_filters as &$filter) {
       $filter = "sameTerm(?model, <info:fedora/$filter>)";
@@ -211,12 +262,11 @@ function islandora_pathauto_bulk_batch_process($use_cron_last = FALSE, &$context
     }
   }
 
-  if ($use_cron_last) {
+  if ($fromdate !== NULL) {
     $args['!md_name'] = '?md';
     $args['!md_field'] = '<info:fedora/fedora-system:def/view#lastModifiedDate> ?md ;';
     if (!isset($sandbox['filters']['cron_last'])) {
-      $modified_date_time = gmdate("Y-m-d\TH:i:s\Z", variable_get('cron_last'));
-      $sandbox['filters']['cron_last'] = "FILTER(?md > '{$modified_date_time}'^^xsd:dateTime)";
+      $sandbox['filters']['cron_last'] = "FILTER(?md > '{$fromdate}'^^xsd:dateTime)";
     }
   }
 
@@ -235,6 +285,10 @@ ORDER BY ?cd
 !limit
 EOQ;
 
+  if ($sandbox['total_processed'] % ($batchsize * 50) === 0) {
+    // Reset tuque connection to solve memory problem.
+    drupal_static_reset('islandora_get_tuque_connection');
+  }
   $tuque = islandora_get_tuque_connection();
   if ($tuque) {
     $context['finished'] = 0;
@@ -256,7 +310,7 @@ EOQ;
     }
 
     $args['!filters'] = implode(' ', $sandbox['filters']);
-    $args['!limit'] = "LIMIT 50";
+    $args['!limit'] = "LIMIT $batchsize";
     $query_string = format_string($query, $args);
 
     $results = $tuque->repository->ri->sparqlQuery($query_string);
@@ -268,23 +322,114 @@ EOQ;
       foreach ($results as $result) {
         $pid = $result['object']['value'];
         $sandbox['cd'] = $result['cd']['value'];
+        if (!isset($sandbox['firstcd'])) {
+          $sandbox['firstcd'] = $sandbox['cd'];
+        }
         $sandbox['pid'] = $pid;
-        $object = islandora_object_load($pid);
-        if ($object) {
-          $alias = islandora_pathauto_create_alias($object, 'bulkupdate');
-          if ($alias != "") {
+        if (isset($context['dryrun']) && $context['dryrun']) {
+          $path = "islandora/object/$pid";
+          $alias = drupal_lookup_path('alias', $path);
+          if ($alias === FALSE || $alias === $path) {
             $sandbox['total_alias']++;
+          }
+        }
+        else {
+          $object = islandora_object_load($pid);
+          if ($object) {
+            $alias = islandora_pathauto_create_alias($object, 'bulkupdate');
+            if ($alias != "") {
+              $sandbox['total_alias']++;
+            }
           }
         }
       }
     }
   }
-  $context['message'] = t('Processed @total_processed of @total. Added @total_alias aliases.', array(
-    '@total_processed' => $sandbox['total_processed'],
-    '@total_alias' => $sandbox['total_alias'],
-    '@total' => $sandbox['total']));
-  if ($context['finished'] == 1) {
-    drupal_set_message(t('Added @total_alias aliases on @total_processed PIDs.', array('@total_alias' => $sandbox['total_alias'], '@total_processed' => $sandbox['total_processed'])));
+}
+
+/**
+ * Batch operation for generating aliases for Islandora objects via Solr.
+ *
+ * @param string $fromdate
+ *   Process only objects that have a modification date greater than this date,
+ *   formatted as YYYY-MM-DD'T'hh:mm:ss'Z', e.g. 2020-05-14T23:59:59Z.
+ * @param array $context
+ *   Batch context.
+ */
+function islandora_pathauto_bulk_batch_process_from_date_solr($fromdate = NULL, &$context = array()) {
+  module_load_include('inc', 'islandora_solr', 'includes/utilities');
+
+  $sandbox = &$context['sandbox'];
+
+  $lastmodfield = "fgs_lastModifiedDate_dt";
+  $solrquery = variable_get('islandora_pathauto_objects_query_solr', '*:*');
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildQuery($solrquery);
+  $qp->solrLimit = 100;
+  $qp->solrStart = $sandbox['total_processed'];
+  $qp->solrParams['fq'] = array();
+  $qp->solrParams['sort'] = "$lastmodfield ASC";
+  $qp->solrParams['fl'] = "PID $lastmodfield";
+
+  $cmf = variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms');
+  $model_filters = $sandbox['models'];
+  foreach ($model_filters as $model) {
+    if ($model !== 'fedora-system:FedoraObject-3.0') {
+      $qp->solrParams['fq'][] = $cmf . ':("' . $model . '" OR "info:fedora/' . $model . '")';
+    }
+  }
+  if (variable_get('islandora_namespace_restriction_enforced', FALSE)) {
+    $namespace_map = function ($namespace) {
+      return 'PID:' . islandora_solr_lesser_escape("$namespace:") . '*';
+    };
+    $qp->solrParams['fq'][] = implode(' OR ', array_map($namespace_map, islandora_get_allowed_namespaces()));
+  }
+
+  if ($fromdate !== NULL) {
+    $qp->solrParams['fq'][] = "$lastmodfield:[$fromdate TO *]";
+  }
+
+  $qp->executeQuery(FALSE);
+  $r = $qp->islandoraSolrResult;
+  $numfound = $r['response']['numFound'];
+  if ($numfound == 0) {
+    $context['finished'] = 1;
+    drupal_set_message(t('No objects found for selected models (@models).', array('@models' => implode(', ', $sandbox['models']))));
+    return t('No objects found.');
+  }
+  $sandbox['total'] = $numfound;
+  $len = count($r['response']['objects']);
+  if ($len === 0) {
+    $context['finished'] = 1;
+  }
+  else {
+    $context['finished'] = $sandbox['total_processed'] / $sandbox['total'];
+  }
+  $sandbox['total_processed'] += $len;
+  for ($i = 0; $i < $len; $i++) {
+    $solrobj = $r['response']['objects'][$i];
+    $pid = $solrobj['PID'];
+    $sandbox['cd'] = $solrobj['solr_doc'][$lastmodfield];
+    if (!isset($sandbox['firstcd'])) {
+      $sandbox['firstcd'] = $sandbox['cd'];
+    }
+    $sandbox['pid'] = $pid;
+    if (isset($context['dryrun']) && $context['dryrun']) {
+      $path = "islandora/object/$pid";
+      $alias = drupal_lookup_path('alias', $path);
+      if ($alias === FALSE || $alias === $path) {
+        $sandbox['total_alias']++;
+      }
+    }
+    else {
+      $object = islandora_object_load($pid);
+      if ($object) {
+        $alias = islandora_pathauto_create_alias($object, 'bulkupdate');
+        if ($alias != "") {
+          $sandbox['total_alias']++;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/ISLANDORA-2508

* Other Relevant Links (related pull requests): PR #19 

# What does this Pull Request do?

This PR adds an option to use Solr for retrieving the object ids when using bulk generate.

# What's new?
In the admin form radio boxes are added to choose between using Sparql or Solr. This defaults to Sparql, just as it used to be. When selecting Solr the Solr query can be changed. It defaults to *:*, but for a multisite a more appropriate query can be given.
Two new configuration variables are added: islandora_pathauto_objects_query_method and islandora_pathauto_objects_query_solr.
The islandora_pathauto.module has been refactored so the Sparql related code is all in one function.

# How should this be tested?

One does not need a multisite to test the new code.
1. configure pathauto
   * setup a pattern at admin/config/search/path/patterns
   * optionally enable custom pathauto settings for content models at admin/islandora/tool/islandora-pathauto and set another pattern for them
2. delete existing aliases at admin/config/search/path/delete-bulk
3. generate the aliases at admin/config/search/path/update-bulk
4. make sure the aliases are generated correctly at admin/config/search/path
5. choose solr at admin/islandora/tool/islandora-pathauto
6. repeat steps 2-4
7. optionally try another solr query
8. optionally use cron to create aliases and/or ingest a new object

# Additional Notes:
This PR affects the configuration screen. The README has been edited, but the screenshots included in the README are external and do not reflect the changes.
This PR should not have any impact on existing configurations, it only adds an extra possibility.
I like to mention PR #19 . I did a new PR because I already started work and later discovered the other PR and also because that PR seems to be abandoned.

# Interested parties
@Islandora/7-x-1-x-committers
@wgilling
